### PR TITLE
Minor bugfixes:

### DIFF
--- a/docs/ErrorCodes.md
+++ b/docs/ErrorCodes.md
@@ -29,3 +29,4 @@ These are the error codes that the Data Extract Facility may produce when runnin
 | 128 | Minimum or maximum row count violation. |
 | 129 | You specified multiple queries while the output was a database. |
 | 130 | A value in the queries element is not an array of hashes. |
+| 131 | Unknown file format. |

--- a/tmpl/error.txt.tmpl
+++ b/tmpl/error.txt.tmpl
@@ -4,6 +4,7 @@ Unfortunately, there was an error when trying to run the following job.
 
 Name: [% job.name %]
 Description: [% job.description %]
+File: [% file %]
 Job ID: [% jobrunid %]
 Placeholder date: [% placeholder_date.ymd() %]
 Started: [% started.strftime('%F %T.%3N%z') %]


### PR DESCRIPTION
 * Rethrow the original error on connection failure
 * The job-run-id parameter is no longer ignored
 * Add filename to the error e-mail
 * Perform the COPY TO STDIN after the presql statement
 * If format is not specified, default to CSV (to match the docs)